### PR TITLE
Feature/Auto Switch Chain

### DIFF
--- a/components/Bowswap/BlockStatus.js
+++ b/components/Bowswap/BlockStatus.js
@@ -1,6 +1,5 @@
 /******************************************************************************
-**	@Author:				Thomas Bouder <Tbouder>
-**	@Email:					Tbouder@protonmail.com
+**	@Author:				Bowswap
 **	@Date:					Saturday July 31st 2021
 **	@Filename:				BlockStatus.js
 ******************************************************************************/

--- a/components/Bowswap/InputToken.js
+++ b/components/Bowswap/InputToken.js
@@ -1,6 +1,5 @@
 /******************************************************************************
-**	@Author:				Thomas Bouder <Tbouder>
-**	@Email:					Tbouder@protonmail.com
+**	@Author:				Bowswap
 **	@Date:					Thursday July 29th 2021
 **	@Filename:				InputToken.js
 ******************************************************************************/

--- a/components/Bowswap/InputTokenDisabled.js
+++ b/components/Bowswap/InputTokenDisabled.js
@@ -1,6 +1,5 @@
 /******************************************************************************
-**	@Author:				Thomas Bouder <Tbouder>
-**	@Email:					Tbouder@protonmail.com
+**	@Author:				Bowswap
 **	@Date:					Thursday July 29th 2021
 **	@Filename:				InputTokenDisabled.js
 ******************************************************************************/

--- a/components/Bowswap/ModalVaultList.js
+++ b/components/Bowswap/ModalVaultList.js
@@ -1,6 +1,5 @@
 /******************************************************************************
-**	@Author:				Thomas Bouder <Tbouder>
-**	@Email:					Tbouder@protonmail.com
+**	@Author:				Bowswap
 **	@Date:					Thursday July 29th 2021
 **	@Filename:				ModalVaultList.js
 ******************************************************************************/

--- a/components/Bowswap/PopoverSlippage.js
+++ b/components/Bowswap/PopoverSlippage.js
@@ -1,6 +1,5 @@
 /******************************************************************************
-**	@Author:				Thomas Bouder <Tbouder>
-**	@Email:					Tbouder@protonmail.com
+**	@Author:				Bowswap
 **	@Date:					Thursday July 29th 2021
 **	@Filename:				PopoverSlippage.js
 ******************************************************************************/

--- a/components/Commons/ModalLogin.js
+++ b/components/Commons/ModalLogin.js
@@ -1,6 +1,5 @@
 /******************************************************************************
-**	@Author:				Thomas Bouder <Tbouder>
-**	@Email:					Tbouder@protonmail.com
+**	@Author:				Bowswap
 **	@Date:					Sunday July 4th 2021
 **	@Filename:				ModalLogin.js
 ******************************************************************************/

--- a/components/Commons/ModalPong.js
+++ b/components/Commons/ModalPong.js
@@ -1,6 +1,5 @@
 /******************************************************************************
-**	@Author:				Thomas Bouder <Tbouder>
-**	@Email:					Tbouder@protonmail.com
+**	@Author:				Bowswap
 **	@Date:					Sunday July 4th 2021
 **	@Filename:				ModalLogin.js
 ******************************************************************************/

--- a/components/Commons/Navbar.js
+++ b/components/Commons/Navbar.js
@@ -1,6 +1,5 @@
 /******************************************************************************
-**	@Author:				Thomas Bouder <Tbouder>
-**	@Email:					Tbouder@protonmail.com
+**	@Author:				Bowswap
 **	@Date:					Sunday July 4th 2021
 **	@Filename:				Navbar.js
 ******************************************************************************/

--- a/components/Commons/Pong.js
+++ b/components/Commons/Pong.js
@@ -1,6 +1,5 @@
 /******************************************************************************
-**	@Author:				Thomas Bouder <Tbouder>
-**	@Email:					Tbouder@protonmail.com
+**	@Author:				Bowswap
 **	@Date:					Wednesday August 11th 2021
 **	@Filename:				Pong.js
 ******************************************************************************/

--- a/components/Commons/Tabs.js
+++ b/components/Commons/Tabs.js
@@ -1,6 +1,5 @@
 /******************************************************************************
-**	@Author:				Thomas Bouder <Tbouder>
-**	@Email:					Tbouder@protonmail.com
+**	@Author:				Bowswap
 **	@Date:					Tuesday August 17th 2021
 **	@Filename:				Tabs.js
 ******************************************************************************/

--- a/components/Credits.js
+++ b/components/Credits.js
@@ -1,6 +1,5 @@
 /******************************************************************************
-**	@Author:				Thomas Bouder <Tbouder>
-**	@Email:					Tbouder@protonmail.com
+**	@Author:				Bowswap
 **	@Date:					Sunday August 8th 2021
 **	@Filename:				Credits.js
 ******************************************************************************/

--- a/components/Icons/Arrow.js
+++ b/components/Icons/Arrow.js
@@ -1,6 +1,5 @@
 /******************************************************************************
-**	@Author:				Thomas Bouder <Tbouder>
-**	@Email:					Tbouder@protonmail.com
+**	@Author:				Bowswap
 **	@Date:					Saturday July 31st 2021
 **	@Filename:				Arrow.js
 ******************************************************************************/

--- a/components/Icons/Error.js
+++ b/components/Icons/Error.js
@@ -1,6 +1,5 @@
 /******************************************************************************
-**	@Author:				Thomas Bouder <Tbouder>
-**	@Email:					Tbouder@protonmail.com
+**	@Author:				Bowswap
 **	@Date:					Saturday July 31st 2021
 **	@Filename:				Error.js
 ******************************************************************************/

--- a/components/Icons/Pending.js
+++ b/components/Icons/Pending.js
@@ -1,6 +1,5 @@
 /******************************************************************************
-**	@Author:				Thomas Bouder <Tbouder>
-**	@Email:					Tbouder@protonmail.com
+**	@Author:				Bowswap
 **	@Date:					Saturday July 31st 2021
 **	@Filename:				Success.js
 ******************************************************************************/

--- a/components/Icons/Success.js
+++ b/components/Icons/Success.js
@@ -1,6 +1,5 @@
 /******************************************************************************
-**	@Author:				Thomas Bouder <Tbouder>
-**	@Email:					Tbouder@protonmail.com
+**	@Author:				Bowswap
 **	@Date:					Saturday July 31st 2021
 **	@Filename:				Success.js
 ******************************************************************************/

--- a/components/Landing/index.js
+++ b/components/Landing/index.js
@@ -1,6 +1,5 @@
 /******************************************************************************
-**	@Author:				Thomas Bouder <Tbouder>
-**	@Email:					Tbouder@protonmail.com
+**	@Author:				Bowswap
 **	@Date:					Wednesday August 25th 2021
 **	@Filename:				index.js
 ******************************************************************************/

--- a/components/YVempire/BlockStatus.js
+++ b/components/YVempire/BlockStatus.js
@@ -1,6 +1,5 @@
 /******************************************************************************
-**	@Author:				Thomas Bouder <Tbouder>
-**	@Email:					Tbouder@protonmail.com
+**	@Author:				Bowswap
 **	@Date:					Saturday July 31st 2021
 **	@Filename:				BlockStatus.js
 ******************************************************************************/

--- a/components/YVempire/ButtonApprove.js
+++ b/components/YVempire/ButtonApprove.js
@@ -1,6 +1,5 @@
 /******************************************************************************
-**	@Author:				Thomas Bouder <Tbouder>
-**	@Email:					Tbouder@protonmail.com
+**	@Author:				Bowswap
 **	@Date:					Thursday August 19th 2021
 **	@Filename:				ButtonApprove.js
 ******************************************************************************/

--- a/components/YVempire/ButtonMigrate.js
+++ b/components/YVempire/ButtonMigrate.js
@@ -1,6 +1,5 @@
 /******************************************************************************
-**	@Author:				Thomas Bouder <Tbouder>
-**	@Email:					Tbouder@protonmail.com
+**	@Author:				Bowswap
 **	@Date:					Thursday August 19th 2021
 **	@Filename:				ButtonMigrate.js
 ******************************************************************************/

--- a/components/YVempire/TableBody.js
+++ b/components/YVempire/TableBody.js
@@ -1,6 +1,5 @@
 /******************************************************************************
-**	@Author:				Thomas Bouder <Tbouder>
-**	@Email:					Tbouder@protonmail.com
+**	@Author:				Bowswap
 **	@Date:					Thursday August 19th 2021
 **	@Filename:				TableBody.js
 ******************************************************************************/

--- a/components/YVempire/TableHead.js
+++ b/components/YVempire/TableHead.js
@@ -1,6 +1,5 @@
 /******************************************************************************
-**	@Author:				Thomas Bouder <Tbouder>
-**	@Email:					Tbouder@protonmail.com
+**	@Author:				Bowswap
 **	@Date:					Thursday August 19th 2021
 **	@Filename:				TableaHead.js
 ******************************************************************************/

--- a/components/YVempire/TableRow.js
+++ b/components/YVempire/TableRow.js
@@ -1,6 +1,5 @@
 /******************************************************************************
-**	@Author:				Thomas Bouder <Tbouder>
-**	@Email:					Tbouder@protonmail.com
+**	@Author:				Bowswap
 **	@Date:					Thursday August 19th 2021
 **	@Filename:				TableBody.js
 ******************************************************************************/

--- a/components/YVempire/index.js
+++ b/components/YVempire/index.js
@@ -1,6 +1,5 @@
 /******************************************************************************
-**	@Author:				Thomas Bouder <Tbouder>
-**	@Email:					Tbouder@protonmail.com
+**	@Author:				Bowswap
 **	@Date:					Wednesday August 18th 2021
 **	@Filename:				yVempire.js
 ******************************************************************************/

--- a/contexts/useAccount.js
+++ b/contexts/useAccount.js
@@ -1,6 +1,5 @@
 /******************************************************************************
-**	@Author:				Thomas Bouder <Tbouder>
-**	@Email:					Tbouder@protonmail.com
+**	@Author:				Bowswap
 **	@Date:					Sunday June 13th 2021
 **	@Filename:				useAccount.js
 ******************************************************************************/
@@ -22,7 +21,7 @@ const	ERC20ABI = [{'constant':true,'inputs':[],'name':'name','outputs':[{'name':
 const AccountContext = createContext();
 
 export const AccountContextApp = ({children}) => {
-	const	{active, provider, getProvider, address} = useWeb3();
+	const	{active, provider, wrongChain, getProvider, address} = useWeb3();
 	const	[nonce, set_nonce] = useState(0);
 	const	[yVempireNotificationCounter, set_yVempireNotificationCounter] = useState(0);
 	const	[balancesOf, set_balancesOf] = useState({});
@@ -108,13 +107,21 @@ export const AccountContextApp = ({children}) => {
 	}, [address]);
 
 	useEffect(() => {
-		if (active && provider && address) {
+		if (wrongChain) {
+			set_balancesOf({});
+			set_allowances({});
+			set_nonce(0);
+		}
+	}, [wrongChain]);
+
+	useEffect(() => {
+		if (active && provider && address && !wrongChain) {
 			retrieveBowswapBalances(),
 			retrieveYVempireBalances();
 			set_nonce(n => n + 1);
 		}
 	// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [provider, address, active]);
+	}, [provider, address, active, wrongChain]);
 
 	async function	updateBalanceOf(addresses) {
 		const	ethcallProvider = new Provider();

--- a/contexts/useWeb3.js
+++ b/contexts/useWeb3.js
@@ -1,6 +1,5 @@
 /******************************************************************************
-**	@Author:				Thomas Bouder <Tbouder>
-**	@Email:					Tbouder@protonmail.com
+**	@Author:				Bowswap
 **	@Date:					Sunday June 13th 2021
 **	@Filename:				useWeb3.js
 ******************************************************************************/
@@ -79,6 +78,16 @@ export const Web3ContextApp = ({children}) => {
 	// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [account, chainId, connector, library, onDesactivate, onUpdate, set_address, set_chainID]);
 
+	const switchChain = useCallback(() => {
+		if (Number(chainID) === 1) {
+			return;
+		}
+		if (!provider || !active) {
+			console.error('Not initialized');
+			return;
+		}
+		provider.send('wallet_switchEthereumChain', [{chainId: '0x1'}]).catch((error) => console.error(error));
+	}, [active, chainID, provider]);
 
 	/**************************************************************************
 	**	connect
@@ -98,12 +107,7 @@ export const Web3ContextApp = ({children}) => {
 			if (active) {
 				deactivate();
 			}
-			const	injected = new InjectedConnector({
-				supportedChainIds: [
-					1, // ETH MAINNET
-					1337, // MAJORNET
-				]
-			});
+			const	injected = new InjectedConnector();
 			activate(injected, undefined, true);
 			set_lastWallet(walletType.METAMASK);
 		} else if (_providerType === walletType.WALLET_CONNECT) {
@@ -163,7 +167,9 @@ export const Web3ContextApp = ({children}) => {
 				initialized,
 				provider: active ? provider : getProvider(),
 				getProvider,
-				currentRPCProvider: provider
+				currentRPCProvider: provider,
+				switchChain,
+				wrongChain: Number(chainID) > 0 && (Number(chainID) !== 1 && Number(chainID) !== 1337)
 			}}>
 			{children}
 		</Web3Context.Provider>

--- a/hook/useDebounce.js
+++ b/hook/useDebounce.js
@@ -1,6 +1,5 @@
 /******************************************************************************
-**	@Author:				Thomas Bouder <Tbouder>
-**	@Email:					Tbouder@protonmail.com
+**	@Author:				Bowswap
 **	@Date:					Thursday July 29th 2021
 **	@Filename:				useDebounce.js
 ******************************************************************************/

--- a/hook/useInputEvent.js
+++ b/hook/useInputEvent.js
@@ -1,6 +1,5 @@
 /******************************************************************************
-**	@Author:				Thomas Bouder <Tbouder>
-**	@Email:					Tbouder@protonmail.com
+**	@Author:				Bowswap
 **	@Date:					Tuesday August 10th 2021
 **	@Filename:				useInputEvent.js
 ******************************************************************************/

--- a/hook/useSecret.js
+++ b/hook/useSecret.js
@@ -1,6 +1,5 @@
 /******************************************************************************
-**	@Author:				Thomas Bouder <Tbouder>
-**	@Email:					Tbouder@protonmail.com
+**	@Author:				Bowswap
 **	@Date:					Tuesday August 10th 2021
 **	@Filename:				useSecret.js
 ******************************************************************************/

--- a/hook/useWindowInFocus.js
+++ b/hook/useWindowInFocus.js
@@ -1,0 +1,27 @@
+/******************************************************************************
+**	@Author:				Bowswap
+**	@Date:					Wednesday September 29th 2021
+**	@Filename:				useWindowInFocus.js
+******************************************************************************/
+
+import React from 'react';
+
+const useWindowInFocus = () => {
+	const [focused, setFocused] = React.useState(true);
+	React.useEffect(() => {
+		const onFocus = () => setFocused(true);
+		const onBlur = () => setFocused(false);
+
+		window.addEventListener('focus', onFocus);
+		window.addEventListener('blur', onBlur);
+
+		return () => {
+			window.removeEventListener('focus', onFocus);
+			window.removeEventListener('blur', onBlur);
+		};
+	}, []);
+
+	return focused;
+};
+
+export default useWindowInFocus;

--- a/next.config.js
+++ b/next.config.js
@@ -1,7 +1,6 @@
 /******************************************************************************
-**	@Author:				Thomas Bouder <Tbouder>
-**	@Email:					Tbouder@protonmail.com
-**	@Date:					Monday August 24th 2020
+**	@Author:				Bowswap
+**	@Date:					Wednesday September 29th 2021
 **	@Filename:				next.config.js
 ******************************************************************************/
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "tbouder",
+  "name": "bowswap",
   "version": "0.1.0",
   "private": true,
   "scripts": {

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,6 +1,5 @@
 /******************************************************************************
-**	@Author:				Thomas Bouder <Tbouder>
-**	@Email:					Tbouder@protonmail.com
+**	@Author:				Bowswap
 **	@Date:					Sunday June 13th 2021
 **	@Filename:				_app.js
 ******************************************************************************/
@@ -15,6 +14,7 @@ import	FullConfetti					from	'react-confetti';
 import	useWeb3, {Web3ContextApp}		from	'contexts/useWeb3';
 import	useAccount, {AccountContextApp}	from	'contexts/useAccount';
 import	useLocalStorage					from	'hook/useLocalStorage';
+import	useWindowInFocus				from	'hook/useWindowInFocus';
 import	Credits							from	'components/Credits';
 import	Navbar							from	'components/Commons/Navbar';
 import	ModalPong						from	'components/Commons/ModalPong';
@@ -68,7 +68,8 @@ function	WithLayout({children, hasSecret}) {
 }
 
 function	AppWrapper(props) {
-	const	{active, address} = useWeb3();
+	const	{switchChain, wrongChain, active, address} = useWeb3();
+	const	windowInFocus = useWindowInFocus();
 	const	{Component, pageProps, router} = props;
 	const	hasSecretCode = useSecretCode();
 	const	[yearnVaultData, set_yearnVaultData] = useState([]);
@@ -76,8 +77,15 @@ function	AppWrapper(props) {
 	const	[prices, set_prices] = useLocalStorage('cgPrices', []);
 	const	{data} = useSWR(`https://api.coingecko.com/api/v3/simple/price?ids=${['bitcoin', 'ethereum', 'aave', 'chainlink', 'tether-eurt']}&vs_currencies=usd`, fetcher, {revalidateOnMount: true, revalidateOnReconnect: true, refreshInterval: 30000, shouldRetryOnError: true, dedupingInterval: 1000, focusThrottleInterval: 5000});
 
+	React.useEffect(() => {
+		if (windowInFocus && wrongChain) {
+			switchChain();
+		}
+	}, [wrongChain, windowInFocus, switchChain]);
+
 	useEffect(() => {
 		set_prices(data);
+	// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [data]);
 
 	useEffect(() => {

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,6 +1,5 @@
 /******************************************************************************
-**	@Author:				Thomas Bouder <Tbouder>
-**	@Email:					Tbouder@protonmail.com
+**	@Author:				Bowswap
 **	@Date:					Sunday July 4th 2021
 **	@Filename:				index.js
 ******************************************************************************/

--- a/pages/migrate.js
+++ b/pages/migrate.js
@@ -1,6 +1,5 @@
 /******************************************************************************
-**	@Author:				Thomas Bouder <Tbouder>
-**	@Email:					Tbouder@protonmail.com
+**	@Author:				Bowswap
 **	@Date:					Sunday July 4th 2021
 **	@Filename:				between-vaults.js
 ******************************************************************************/

--- a/pages/swap.js
+++ b/pages/swap.js
@@ -1,6 +1,5 @@
 /******************************************************************************
-**	@Author:				Thomas Bouder <Tbouder>
-**	@Email:					Tbouder@protonmail.com
+**	@Author:				Bowswap
 **	@Date:					Sunday July 4th 2021
 **	@Filename:				between-vaults.js
 ******************************************************************************/

--- a/scripts/currentPaths.js
+++ b/scripts/currentPaths.js
@@ -1,6 +1,5 @@
 /******************************************************************************
-**	@Author:				Thomas Bouder <Tbouder>
-**	@Email:					Tbouder@protonmail.com
+**	@Author:				Bowswap
 **	@Date:					Thursday August 19th 2021
 **	@Filename:				currentPaths.js
 ******************************************************************************/

--- a/style/Default.css
+++ b/style/Default.css
@@ -1,11 +1,8 @@
-/*******************************************************************************
-** @Author:					Thomas Bouder <Tbouder>
-** @Email:					Tbouder@protonmail.com
-** @Date:					Friday 16 October 2020 - 10:36:26
-** @Filename:				Default.css
-**
-** @Last modified by:		Tbouder
-*******************************************************************************/
+/******************************************************************************
+**	@Author:				Bowswap
+**	@Date:					Tuesday September 28th 2021
+**	@Filename:				Default.css
+******************************************************************************/
 
 html {
 	background-color: #F2F3F5;

--- a/utils/API.js
+++ b/utils/API.js
@@ -1,6 +1,5 @@
 /******************************************************************************
-**	@Author:				Thomas Bouder <Tbouder>
-**	@Email:					Tbouder@protonmail.com
+**	@Author:				Bowswap
 **	@Date:					Saturday January 2nd 2021
 **	@Filename:				API.js
 ******************************************************************************/

--- a/utils/AaveV1.js
+++ b/utils/AaveV1.js
@@ -1,6 +1,5 @@
 /******************************************************************************
-**	@Author:				Thomas Bouder <Tbouder>
-**	@Email:					Tbouder@protonmail.com
+**	@Author:				Bowswap
 **	@Date:					Thursday August 12th 2021
 **	@Filename:				AaveV1.js
 ******************************************************************************/

--- a/utils/AaveV2.js
+++ b/utils/AaveV2.js
@@ -1,6 +1,5 @@
 /******************************************************************************
-**	@Author:				Thomas Bouder <Tbouder>
-**	@Email:					Tbouder@protonmail.com
+**	@Author:				Bowswap
 **	@Date:					Thursday August 12th 2021
 **	@Filename:				AaveV2.js
 ******************************************************************************/

--- a/utils/Compound.js
+++ b/utils/Compound.js
@@ -1,6 +1,5 @@
 /******************************************************************************
-**	@Author:				Thomas Bouder <Tbouder>
-**	@Email:					Tbouder@protonmail.com
+**	@Author:				Bowswap
 **	@Date:					Thursday August 12th 2021
 **	@Filename:				AaveV2.js
 ******************************************************************************/

--- a/utils/actions.js
+++ b/utils/actions.js
@@ -1,6 +1,5 @@
 /******************************************************************************
-**	@Author:				Thomas Bouder <Tbouder>
-**	@Email:					Tbouder@protonmail.com
+**	@Author:				Bowswap
 **	@Date:					Wednesday July 14th 2021
 **	@Filename:				actions.js
 ******************************************************************************/

--- a/utils/currentPaths.js
+++ b/utils/currentPaths.js
@@ -1,6 +1,5 @@
 /******************************************************************************
-**	@Author:				Thomas Bouder <Tbouder>
-**	@Email:					Tbouder@protonmail.com
+**	@Author:				Bowswap
 **	@Date:					Thursday August 19th 2021
 **	@Filename:				currentPaths.js
 ******************************************************************************/

--- a/utils/index.js
+++ b/utils/index.js
@@ -1,6 +1,5 @@
 /******************************************************************************
-**	@Author:				Thomas Bouder <Tbouder>
-**	@Email:					Tbouder@protonmail.com
+**	@Author:				Bowswap
 **	@Date:					Thursday March 18th 2021
 **	@Filename:				index.js
 ******************************************************************************/


### PR DESCRIPTION
## What it does ✨
With the current auto chain switch logic, it is disruptive when users have multiple dapps open across different chains. Add a hook to check whether window is in focus and only prompt to chain network when it is in focus.

Also, fix a bug where `supportedChainIds` was set to a narrow set. This made the page swallow error when connecting wallet from an unknown network. Now that we have chain switch code, we can accept any network and prompt user to switch after wallet is injected.

To reproduce this error, start the dapp with an unsupported network, e.g. polygon, and users do not get prompt to change network.

Also update the Header to `Bowswap`


Based on the work on this PR : https://github.com/Rarity-Extended/RarityExtended/pull/32