### PR TITLE
Feature/yVempire yield display

### DIFF
--- a/components/Bowswap/ModalVaultList.js
+++ b/components/Bowswap/ModalVaultList.js
@@ -39,8 +39,8 @@ function	VaultList({element, onClick, style, balanceOf}) {
 	);
 }
 
-function ModalVaultList({vaults, yearnVaultData, label, value, set_value, set_input, isFrom, disabled}) {
-	const	{balancesOf} = useAccount();
+function ModalVaultList({vaults, label, value, set_value, set_input, isFrom, disabled}) {
+	const	{balancesOf, yearnVaultData} = useAccount();
 	const	[open, set_open] = useState(false);
 	const	[nonce, set_nonce] = useState(0);
 	const	[searchFilter, set_searchFilter] = useState('');

--- a/components/Bowswap/index.js
+++ b/components/Bowswap/index.js
@@ -427,9 +427,9 @@ function	ButtonApprove({fromVault, fromAmount, approved, disabled, set_signature
 	);
 }
 
-function	Bowswap({yearnVaultData, prices}) {
+function	Bowswap({prices}) {
 	const	{provider} = useWeb3();
-	const	{balancesOf, updateBalanceOf, allowances} = useAccount();
+	const	{balancesOf, updateBalanceOf, allowances, yearnVaultData} = useAccount();
 	const	[, set_nonce] = useState(0);
 	const	[fromVault, set_fromVault] = useLocalStorage('fromVault', BOWSWAP_CRV_USD_VAULTS[0]);
 	const	[fromCounterValue, set_fromCounterValue] = useLocalStorage('fromCounterValue', 0);

--- a/components/Commons/Tabs.js
+++ b/components/Commons/Tabs.js
@@ -1,8 +1,24 @@
 import	React			from	'react';
 import	{useRouter}		from	'next/router';
+import	useAccount		from	'contexts/useAccount';
 
-export default function Tabs({yVempireNotificationCounter}) {
-	const router = useRouter();
+export default function Tabs() {
+	const	router = useRouter();
+	const	[amount, set_amount] = React.useState(0);
+
+	const	{yVempireNotificationCounter, yVempireData, balancesOf} = useAccount();
+
+	React.useEffect(() => {
+		set_amount(0);
+		Object.entries(yVempireNotificationCounter).forEach(([key, value]) => {
+			const pair = yVempireData.find(e => (e?.uToken?.address).toLowerCase() === key.toLowerCase());
+			if (Number(pair.uToken.apy) <= Number(pair.yvToken.apy)) {
+				if (value >= 100) {
+					set_amount(a => a + 1);
+				}
+			}
+		});
+	}, [yVempireNotificationCounter, balancesOf, yVempireData]);
 
 	return (
 		<div className={'flex items-center justify-between bg-white rounded-xl shadow-base p-1 w-full relative space-x-2'}>
@@ -16,10 +32,10 @@ export default function Tabs({yVempireNotificationCounter}) {
 				className={`${router.pathname === '/migrate' ? 'bg-ygray-50 text-opacity-100 font-bold' : 'bg-white text-opacity-50 font-normal cursor-pointer hover:bg-ygray-50 hover:bg-opacity-50 hover:text-opacity-70'} transition-all text-yblue w-full text-ybase rounded-lg focus:outline-none py-4 flex justify-center items-center tracking-wide relative`}>
 				<p className={'hidden md:inline'}>{'From DeFi to Yearn Vault'}</p>
 				<p className={'inline md:hidden'}>{'From DeFi'}</p>
-				{router.pathname !== '/migrate' && yVempireNotificationCounter > 0 ? <span className={'flex h-6 w-6 absolute -top-3 -right-3 z-50'}>
+				{router.pathname !== '/migrate' && amount > 0 ? <span className={'flex h-6 w-6 absolute -top-3 -right-3 z-50'}>
 					<span className={'animate-ping absolute inline-flex h-full w-full rounded-full bg-yblue opacity-75'}></span>
 					<span className={'relative inline-flex rounded-full h-6 w-6 bg-yblue justify-center items-center'}>
-						<p className={'text-white text-sm font-semibold font-sans'}>{yVempireNotificationCounter}</p>
+						<p className={'text-white text-sm font-semibold font-sans'}>{amount}</p>
 					</span>
 				</span> : null}
 			</div>

--- a/components/YVempire/TableRow.js
+++ b/components/YVempire/TableRow.js
@@ -5,14 +5,14 @@ import	Arrow						from	'components/Icons/Arrow';
 import	{formatAmount}				from	'utils';
 
 function	TableRow({pair, balanceOf, yearnVaultData, selectedTokens, set_nonce, onSelectToken}) {
-	const	[isChecked, set_isChecked] = useState(false); //used to update the localstate
+	const	[isChecked, set_isChecked] = useState(false);
 	const	disabled = balanceOf?.isZero() || !balanceOf;
+	if (pair?.uToken?.isHidden) {
+		return null;
+	}
 
 	const	yearnAPY = Number((yearnVaultData?.apy?.net_apy || 0) * 100);
 	const	uAPY = Number(pair.uToken.apy);
-	if (uAPY > yearnAPY) {
-		return null;
-	}
 
 	return (
 		<tr className={'bg-white z-10 relative'}>

--- a/components/YVempire/TableRow.js
+++ b/components/YVempire/TableRow.js
@@ -8,6 +8,12 @@ function	TableRow({pair, balanceOf, yearnVaultData, selectedTokens, set_nonce, o
 	const	[isChecked, set_isChecked] = useState(false); //used to update the localstate
 	const	disabled = balanceOf?.isZero() || !balanceOf;
 
+	const	yearnAPY = Number((yearnVaultData?.apy?.net_apy || 0) * 100);
+	const	uAPY = Number(pair.uToken.apy);
+	if (uAPY > yearnAPY) {
+		return null;
+	}
+
 	return (
 		<tr className={'bg-white z-10 relative'}>
 			<td>
@@ -41,7 +47,7 @@ function	TableRow({pair, balanceOf, yearnVaultData, selectedTokens, set_nonce, o
 							</div>
 							<div className={'pl-4 text-left overflow-ellipsis'}>
 								<div className={'text-ybase font-medium whitespace-nowrap'}>{pair.uToken.name}</div>
-								<div className={'text-ybase text-ygray-400 overflow-ellipsis mt-1'}>{`${Number(pair.uToken.apy).toFixed(2)}%`}</div>
+								<div className={'text-ybase text-ygray-400 overflow-ellipsis mt-1'}>{`${uAPY.toFixed(2)}%`}</div>
 							</div>
 						</div>
 
@@ -61,7 +67,7 @@ function	TableRow({pair, balanceOf, yearnVaultData, selectedTokens, set_nonce, o
 								</div>
 								<div className={'pl-4 text-left overflow-ellipsis'}>
 									<div className={'text-ybase font-medium whitespace-nowrap'}>{pair.yvToken.name}</div>
-									<div key={pair.yvToken.apy} className={'text-ybase font-medium text-yblue overflow-ellipsis mt-1'}>{`${Number((yearnVaultData?.apy?.net_apy || 0) * 100).toFixed(2)}%`}</div>
+									<div key={pair.yvToken.apy} className={'text-ybase font-medium text-yblue overflow-ellipsis mt-1'}>{`${yearnAPY.toFixed(2)}%`}</div>
 								</div>
 							</div>
 						</div>

--- a/components/YVempire/index.js
+++ b/components/YVempire/index.js
@@ -1,28 +1,20 @@
-import	React, {useState, useEffect, useCallback}			from	'react';
-import	{ethers}											from	'ethers';
-import	useWeb3												from	'contexts/useWeb3';
-import	useAccount											from	'contexts/useAccount';
-import	BlockStatus											from	'components/YVempire/BlockStatus';
-import	ButtonMigrate										from	'components/YVempire/ButtonMigrate';
-import	ButtonApprove										from	'components/YVempire/ButtonApprove';
-import	TableHead											from	'components/YVempire/TableHead';
-import	TableBody											from	'components/YVempire/TableBody';
-import	Success												from	'components/Icons/Success';
-import	Error												from	'components/Icons/Error';
-import	Pending												from	'components/Icons/Pending';
-import	{asyncForEach}										from	'utils';
+import	React, {useState, useEffect}		from	'react';
+import	{ethers}							from	'ethers';
+import	useWeb3								from	'contexts/useWeb3';
+import	useAccount							from	'contexts/useAccount';
+import	BlockStatus							from	'components/YVempire/BlockStatus';
+import	ButtonMigrate						from	'components/YVempire/ButtonMigrate';
+import	ButtonApprove						from	'components/YVempire/ButtonApprove';
+import	TableHead							from	'components/YVempire/TableHead';
+import	TableBody							from	'components/YVempire/TableBody';
+import	Success								from	'components/Icons/Success';
+import	Error								from	'components/Icons/Error';
+import	Pending								from	'components/Icons/Pending';
 
-const	LENDING_POOL_ADDRESS = '0x7d2768dE32b0b80b7a3454c06BdAc94A69DDc7A9';
-const	LENDING_POOL_ABI = [
-	{'inputs':[{'internalType':'address','name':'asset','type':'address'}],'name':'getReserveData','outputs':[{'components':[{'components':[{'internalType':'uint256','name':'data','type':'uint256'}],'internalType':'struct DataTypes.ReserveConfigurationMap','name':'configuration','type':'tuple'},{'internalType':'uint128','name':'liquidityIndex','type':'uint128'},{'internalType':'uint128','name':'variableBorrowIndex','type':'uint128'},{'internalType':'uint128','name':'currentLiquidityRate','type':'uint128'},{'internalType':'uint128','name':'currentVariableBorrowRate','type':'uint128'},{'internalType':'uint128','name':'currentStableBorrowRate','type':'uint128'},{'internalType':'uint40','name':'lastUpdateTimestamp','type':'uint40'},{'internalType':'address','name':'aTokenAddress','type':'address'},{'internalType':'address','name':'stableDebtTokenAddress','type':'address'},{'internalType':'address','name':'variableDebtTokenAddress','type':'address'},{'internalType':'address','name':'interestRateStrategyAddress','type':'address'},{'internalType':'uint8','name':'id','type':'uint8'}],'internalType':'struct DataTypes.ReserveData','name':'','type':'tuple'}],'stateMutability':'view','type':'function'}
-];
-let	lastReload = 0;
-
-function	YVempire({yearnVaultData, yVempireData, set_yVempireData}) {
-	const	{provider, address} = useWeb3();
-	const	{balancesOf, allowances, set_balancesOf, set_allowances, set_yVempireNotificationCounter} = useAccount();
+function	YVempire() {
+	const	{address} = useWeb3();
+	const	{balancesOf, allowances, set_balancesOf, set_allowances, set_yVempireNotificationCounter, yearnVaultData, yVempireData} = useAccount();
 	const	[, set_nonce] = useState(0);
-	const	[isUpdating, set_isUpdating] = useState(false);
 	const	[selectedTokens, set_selectedTokens] = useState([]);
 
 	const	[txApproveStatus, set_txApproveStatus] = useState({none: true, pending: false, success: false, error: false, step: ''});
@@ -39,48 +31,6 @@ function	YVempire({yearnVaultData, yVempireData, set_yVempireData}) {
 		set_txMigrateStatus({none: true, pending: false, success: false, error: false});
 		set_nonce(n => n + 1);
 	}, [address]);
-
-	const	retrieveUTokenBalances = useCallback(async () => {
-		if (!provider || (!yearnVaultData || yearnVaultData.length === 0) || isUpdating) {
-			return;
-		}
-		const	now = new Date().valueOf();
-		if (now - lastReload < 10000) {
-			return;
-		}
-		lastReload = now;
-		set_isUpdating(true);
-		const	yearnVaults = yearnVaultData;
-		const	aLendingPoolContract = new ethers.Contract(LENDING_POOL_ADDRESS, LENDING_POOL_ABI, provider);
-		const	_yVempireData = yVempireData;
-
-		await asyncForEach(_yVempireData, async (pair, index) => {
-			const	fromTokenContract = new ethers.Contract(pair.uToken.address, ['function supplyRatePerBlock() view returns (uint256)'], provider);
-			const	currentYearnVault = yearnVaults.find(yv => yv.address === pair.yvToken.address);
-			_yVempireData[index].yvToken.apy = (currentYearnVault?.apy?.net_apy || 0) * 100;
-
-			if (pair.service === 0) {
-				const	supplyRatePerBlock = await fromTokenContract.supplyRatePerBlock();
-				const ethMantissa = 1e18;
-				const blocksPerDay = 6570;
-				const daysPerYear = 365;
-				const supplyApy = (((Math.pow((supplyRatePerBlock / ethMantissa * blocksPerDay) + 1, daysPerYear))) - 1) * 100;
-				_yVempireData[index].uToken.apy = supplyApy;
-			} else {
-				const	reserveData = await aLendingPoolContract.getReserveData(pair.underlyingAddress);
-				_yVempireData[index].uToken.apy = ethers.utils.formatUnits(reserveData.currentLiquidityRate, 25);
-			}
-			set_yVempireData(p => {p[index] = _yVempireData[index]; return p;});
-			set_nonce(n => n + 1);
-		});
-		set_isUpdating(false);
-	// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [provider, yearnVaultData]);
-
-	useEffect(() => {
-		retrieveUTokenBalances();
-	}, [retrieveUTokenBalances]);
-
 
 	async function resetUTokenBalances(selectedTokensList) {
 		const	migrated = {};

--- a/components/YVempire/index.js
+++ b/components/YVempire/index.js
@@ -13,7 +13,7 @@ import	Pending								from	'components/Icons/Pending';
 
 function	YVempire() {
 	const	{address} = useWeb3();
-	const	{balancesOf, allowances, set_balancesOf, set_allowances, set_yVempireNotificationCounter, yearnVaultData, yVempireData} = useAccount();
+	const	{balancesOf, allowances, set_balancesOf, set_allowances, yearnVaultData, yVempireData} = useAccount();
 	const	[, set_nonce] = useState(0);
 	const	[selectedTokens, set_selectedTokens] = useState([]);
 
@@ -128,7 +128,6 @@ function	YVempire() {
 								setTimeout(() => set_txMigrateStatus((s) => s.error ? {none: true, pending: false, error: false, success: false} : s), 2500);
 							}
 							if (type === 'success') {
-								set_yVempireNotificationCounter(n => n - selectedTokensList.length);
 								resetUTokenBalances(selectedTokensList);
 								set_txApproveStatus({none: true, pending: false, success: false, error: false, step: ''});
 								setTimeout(() => {

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -6,22 +6,17 @@ import	{ethers}						from	'ethers';
 import	useSWR							from	'swr';
 import	FullConfetti					from	'react-confetti';
 import	useWeb3, {Web3ContextApp}		from	'contexts/useWeb3';
-import	useAccount, {AccountContextApp}	from	'contexts/useAccount';
+import	{AccountContextApp}				from	'contexts/useAccount';
 import	useLocalStorage					from	'hook/useLocalStorage';
 import	Credits							from	'components/Credits';
 import	Navbar							from	'components/Commons/Navbar';
 import	ModalPong						from	'components/Commons/ModalPong';
 import	Tabs							from	'components/Commons/Tabs';
 import	useSecret						from	'hook/useSecret';
-import	{fetchYearnVaults}				from	'utils/API';
-import	AAVE_V1							from	'utils/AaveV1';
-import	AAVE_V2							from	'utils/AaveV2';
-import	COMPOUND						from	'utils/Compound';
 
 import	'style/Default.css';
 import	'tailwindcss/tailwind.css';
 
-const	PAIRS = [...COMPOUND, ...AAVE_V1, ...AAVE_V2];
 const	fetcher = (...args) => fetch(...args).then(res => res.json());
 const	useSecretCode = () => {
 	const secretCode = process.env.SECRET.split(',');
@@ -31,12 +26,11 @@ const	useSecretCode = () => {
 
 function	WithLayout({children, hasSecret}) {
 	const	[triggerPong, set_triggerPong] = useState(false);
-	const	{yVempireNotificationCounter} = useAccount();
 	return (
 		<section className={'w-full md:px-12 px-4 space-y-12 mb-64 z-10 relative'}>
 			<div className={'flex flex-col w-full justify-center items-center'}>
 				<div className={'w-full max-w-2xl mb-2'}>
-					<Tabs yVempireNotificationCounter={yVempireNotificationCounter} />
+					<Tabs />
 				</div>
 				<div className={'w-full max-w-2xl'}>
 					{children}
@@ -64,8 +58,6 @@ function	AppWrapper(props) {
 	const	{active, address} = useWeb3();
 	const	{Component, pageProps, router} = props;
 	const	hasSecretCode = useSecretCode();
-	const	[yearnVaultData, set_yearnVaultData] = useState([]);
-	const	[yVempireData, set_yVempireData] = useState(PAIRS);
 	const	[prices, set_prices] = useLocalStorage('cgPrices', []);
 	const	{data} = useSWR(`https://api.coingecko.com/api/v3/simple/price?ids=${['bitcoin', 'ethereum', 'aave', 'chainlink', 'tether-eurt']}&vs_currencies=usd`, fetcher, {revalidateOnMount: true, revalidateOnReconnect: true, refreshInterval: 30000, shouldRetryOnError: true, dedupingInterval: 1000, focusThrottleInterval: 5000});
 
@@ -79,15 +71,6 @@ function	AppWrapper(props) {
 		}
 	// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [active, address]);
-
-	const	retrieveYearnVaults = React.useCallback(async () => {
-		const	vaults = await fetchYearnVaults();
-		set_yearnVaultData(vaults);
-	}, []);
-
-	useEffect(() => {
-		retrieveYearnVaults();
-	}, [retrieveYearnVaults]);
 
 	return (
 		<>
@@ -154,9 +137,6 @@ function	AppWrapper(props) {
 								router={props.router}
 								hasSecret={active && hasSecretCode}
 								prices={prices}
-								yearnVaultData={yearnVaultData}
-								yVempireData={yVempireData}
-								set_yVempireData={set_yVempireData}
 								{...pageProps} />
 						</WithLayout>
 					</div>

--- a/pages/migrate.js
+++ b/pages/migrate.js
@@ -1,8 +1,8 @@
 import	React		from	'react';
 import	YVempire	from	'components/YVempire';
 
-function	FromDefi({yearnVaultData, yVempireData, set_yVempireData}) {
-	return <YVempire yearnVaultData={yearnVaultData} yVempireData={yVempireData} set_yVempireData={set_yVempireData} />;
+function	FromDefi() {
+	return <YVempire />;
 }
 
 export default FromDefi;

--- a/pages/swap.js
+++ b/pages/swap.js
@@ -1,8 +1,8 @@
 import	React		from	'react';
 import	Bowswap		from	'components/Bowswap';
 
-function	BetweenVaults({yearnVaultData, prices}) {
-	return <Bowswap yearnVaultData={yearnVaultData} prices={prices} />;
+function	BetweenVaults({prices}) {
+	return <Bowswap prices={prices} />;
 }
 
 export default BetweenVaults;

--- a/utils/actions.js
+++ b/utils/actions.js
@@ -42,7 +42,6 @@ export async function	signTransaction({provider, vaultAddress, contractAddress, 
 	} catch (error) {
 		return callback({error: error, data: undefined});
 	}
-	console.log({signature});
 
 	return callback({error: false, data: signature});
 }


### PR DESCRIPTION
## Description
Hide the rows to migrate from AAVE/Compound to Yearn when the yield is better on AAVE/Compound side.

Fixes #49 

## Type of change
- [X] New feature with potential breaking change

## Change details
The comparison between the two APY is easy, but to display the number of migration available through yVempire on the notification number was harder and a refactor was needed