### PR TITLE
Feature/Disable old TriCrypto

### DIFF
--- a/components/Bowswap/index.js
+++ b/components/Bowswap/index.js
@@ -182,7 +182,7 @@ function	Bowswap({prices}) {
 			return;
 		}
 		const	V2Paths = V2_PATHS.filter(e => toAddress(e[0]) === toAddress(fromVault.address)).map(e => e[1]);
-		const	V2VaultList = BOWSWAP_CRV_V2_VAULTS.filter(e => V2Paths.includes(toAddress(e.address)));
+		const	V2VaultList = BOWSWAP_CRV_V2_VAULTS.filter(e => V2Paths.includes(toAddress(e.address)) && e.withdrawOnly === false);
 		set_toVaultsListV2(V2VaultList);
 
 		if (fromVault.scope === 'btc') {
@@ -284,7 +284,7 @@ function	Bowswap({prices}) {
 					expectedReceiveAmount={expectedReceiveAmount}
 					toCounterValue={toCounterValue}
 					slippage={slippage}
-					balanceOf={balancesOf[toVault.address]?.toString() || '0'}
+					balanceOf={balancesOf[toVault?.address]?.toString() || '0'}
 					isFetchingExpectedReceiveAmount={isFetchingExpectedReceiveAmount}
 					yearnVaultData={yearnVaultData} />
 

--- a/utils/BOWSWAP_CRV_BTC_VAULTS.json
+++ b/utils/BOWSWAP_CRV_BTC_VAULTS.json
@@ -6,6 +6,7 @@
 		"name": "Curve pBTC Pool yVault",
 		"decimals": 18,
 		"scope": "btc",
+		"withdrawOnly": false,
 		"address": "0x3c5DF3077BcF800640B5DAE8c91106575a4826E6",
 		"tokenAddress": "0xDE5331AC4B3630f94853Ff322B66407e0D6331E8",
 		"poolAddress": "0x7f55dde206dbad629c080068923b36fe9d6bdbef"
@@ -17,6 +18,7 @@
 		"displayName": "crvBBTC",
 		"decimals": 18,
 		"scope": "btc",
+		"withdrawOnly": false,
 		"address": "0x8fA3A9ecd9EFb07A8CE90A6eb014CF3c0E3B32Ef",
 		"tokenAddress": "0x410e3E86ef427e30B9235497143881f717d93c2A",
 		"poolAddress": "0x071c661b4deefb59e2a3ddb20db036821eee8f4b"
@@ -28,6 +30,7 @@
 		"displayName": "crvOBTC",
 		"decimals": 18,
 		"scope": "btc",
+		"withdrawOnly": false,
 		"address": "0xe9Dc63083c464d6EDcCFf23444fF3CFc6886f6FB",
 		"tokenAddress": "0x2fE94ea3d5d4a175184081439753DE15AeF9d614",
 		"poolAddress": "0xd81da8d904b52208541bade1bd6595d8a251f8dd"
@@ -39,6 +42,7 @@
 		"displayName": "crvTBTC",
 		"decimals": 18,
 		"scope": "btc",
+		"withdrawOnly": false,
 		"address": "0x23D3D0f1c697247d5e0a9efB37d8b0ED0C464f7f",
 		"tokenAddress": "0x64eda51d3Ad40D56b9dFc5554E06F94e1Dd786Fd",
 		"poolAddress": "0xC25099792E9349C7DD09759744ea681C7de2cb66"

--- a/utils/BOWSWAP_CRV_EUR_VAULTS.json
+++ b/utils/BOWSWAP_CRV_EUR_VAULTS.json
@@ -6,6 +6,7 @@
 		"name": "yvCurve-EURS 0.3.5",
 		"decimals": 18,
 		"scope": "eur",
+		"withdrawOnly": false,
 		"address": "0x25212Df29073FfFA7A67399AcEfC2dd75a831A1A",
 		"tokenAddress": "0x194eBd173F6cDacE046C53eACcE9B953F28411d1",
 		"poolAddress": "0x0ce6a5ff5217e38315f87032cf90686c96627caa"
@@ -17,6 +18,7 @@
 		"displayName": "crvEURT",
 		"decimals": 18,
 		"scope": "eur",
+		"withdrawOnly": false,
 		"address": "0x0d4EA8536F9A13e4FBa16042a46c30f092b06aA5",
 		"tokenAddress": "0xFD5dB7463a3aB53fD211b4af195c5BCCC1A03890",
 		"poolAddress": "0xFD5dB7463a3aB53fD211b4af195c5BCCC1A03890"

--- a/utils/BOWSWAP_CRV_USD_VAULTS.json
+++ b/utils/BOWSWAP_CRV_USD_VAULTS.json
@@ -6,6 +6,7 @@
 		"displayName": "crvUSDP",
 		"decimals": 18,
 		"scope": "usd",
+		"withdrawOnly": false,
 		"address": "0xC4dAf3b5e2A9e93861c3FBDd25f1e943B8D87417",
 		"tokenAddress": "0x7Eb40E450b9655f4B3cC4259BCC731c63ff55ae6",
 		"poolAddress": "0x42d7025938bEc20B69cBae5A77421082407f053A"
@@ -17,6 +18,7 @@
 		"displayName": "crvMUSD",
 		"decimals": 18,
 		"scope": "usd",
+		"withdrawOnly": false,
 		"address": "0x8cc94ccd0f3841a468184aCA3Cc478D2148E1757",
 		"tokenAddress": "0x1AEf73d49Dedc4b1778d0706583995958Dc862e6",
 		"poolAddress": "0x8474DdbE98F5aA3179B3B3F5942D724aFcdec9f6"
@@ -28,6 +30,7 @@
 		"displayName": "crvLUSD",
 		"decimals": 18,
 		"scope": "usd",
+		"withdrawOnly": false,
 		"address": "0x5fA5B62c8AF877CB37031e0a3B2f34A78e3C56A6",
 		"tokenAddress": "0xEd279fDD11cA84bEef15AF5D39BB4d4bEE23F0cA",
 		"poolAddress": "0xEd279fDD11cA84bEef15AF5D39BB4d4bEE23F0cA"
@@ -39,6 +42,7 @@
 		"displayName": "crvDUSD",
 		"decimals": 18,
 		"scope": "usd",
+		"withdrawOnly": false,
 		"address": "0x30FCf7c6cDfC46eC237783D94Fc78553E79d4E9C",
 		"tokenAddress": "0x3a664Ab939FD8482048609f652f9a0B0677337B9",
 		"poolAddress": "0x8038C01A0390a8c547446a0b2c18fc9aEFEcc10c"
@@ -50,6 +54,7 @@
 		"displayName": "crvTUSD",
 		"decimals": 18,
 		"scope": "usd",
+		"withdrawOnly": false,
 		"address": "0xf8768814b88281DE4F532a3beEfA5b85B69b9324",
 		"tokenAddress": "0xEcd5e75AFb02eFa118AF914515D6521aaBd189F1",
 		"poolAddress": "0xEcd5e75AFb02eFa118AF914515D6521aaBd189F1"
@@ -61,6 +66,7 @@
 		"displayName": "crvHUSD",
 		"decimals": 18,
 		"scope": "usd",
+		"withdrawOnly": false,
 		"address": "0x054AF22E1519b020516D72D749221c24756385C9",
 		"tokenAddress": "0x5B5CFE992AdAC0C9D48E05854B2d91C73a003858",
 		"poolAddress": "0x3eF6A01A0f81D6046290f3e2A8c5b843e738E604"
@@ -72,6 +78,7 @@
 		"displayName": "crvUSDN",
 		"decimals": 18,
 		"scope": "usd",
+		"withdrawOnly": false,
 		"address": "0x3B96d491f067912D18563d56858Ba7d6EC67a6fa",
 		"tokenAddress": "0x4f3E8F405CF5aFC05D68142F3783bDfE13811522",
 		"poolAddress": "0x0f9cb53Ebe405d49A0bbdBD291A65Ff571bC83e1"
@@ -82,6 +89,7 @@
 		"name": "Curve BUSD Pool yVault",
 		"decimals": 18,
 		"scope": "usd",
+		"withdrawOnly": false,
 		"displayName": "crvBUSD",
 		"address": "0x6Ede7F19df5df6EF23bD5B9CeDb651580Bdf56Ca",
 		"tokenAddress": "0x4807862AA8b2bF68830e4C8dc86D0e9A998e085a",
@@ -93,6 +101,7 @@
 		"name": "Curve UST Pool yVault",
 		"decimals": 18,
 		"scope": "usd",
+		"withdrawOnly": false,
 		"displayName": "crvUST",
 		"address": "0x1C6a9783F812b3Af3aBbf7de64c3cD7CC7D1af44",
 		"tokenAddress": "0x94e131324b6054c0D789b190b2dAC504e4361b53",
@@ -104,6 +113,7 @@
 		"name": "Curve alUSD Pool yVault",
 		"decimals": 18,
 		"scope": "usd",
+		"withdrawOnly": false,
 		"displayName": "crvALUSD",
 		"address": "0xA74d4B67b3368E83797a35382AFB776bAAE4F5C8",
 		"tokenAddress": "0x43b4FdFD4Ff969587185cDB6f0BD875c5Fc83f8c",
@@ -116,6 +126,7 @@
 		"displayName": "Curve RSV",
         "decimals": 18,
 		"scope": "usd",
+		"withdrawOnly": false,
         "address": "0xC116dF49c02c5fD147DE25Baa105322ebF26Bd97",
         "tokenAddress": "0xC2Ee6b0334C261ED60C72f6054450b61B8f18E35",
         "poolAddress": "0xC18cC39da8b11dA8c3541C598eE022258F9744da"
@@ -127,6 +138,7 @@
 		"displayName": "Curve MIM",
 		"decimals": 18,
 		"scope": "usd",
+		"withdrawOnly": false,
 		"address": "0x2DfB14E32e2F8156ec15a2c21c3A6c053af52Be8",
 		"tokenAddress": "0x5a6A4D54456819380173272A5E8E9B9904BdF41B",
         "poolAddress": "0x5a6A4D54456819380173272A5E8E9B9904BdF41B"

--- a/utils/BOWSWAP_CRV_V2_VAULTS.json
+++ b/utils/BOWSWAP_CRV_V2_VAULTS.json
@@ -6,6 +6,7 @@
         "decimals": 18,
         "scope": "v2",
         "type": "btc",
+        "withdrawOnly": false,
         "address": "0x625b7DF2fa8aBe21B0A976736CDa4775523aeD1E",
         "tokenAddress": "0xb19059ebb43466C323583928285a49f558E572Fd",
         "poolAddress": "0x4CA9b3063Ec5866A4B82E437059D2C43d1be596F"
@@ -17,6 +18,7 @@
         "decimals": 18,
         "scope": "v2",
         "type": "btc",
+        "withdrawOnly": false,
         "address": "0x8414Db07a7F743dEbaFb402070AB01a4E0d2E45e",
         "tokenAddress": "0x075b1bb99792c9E1041bA13afEf80C91a1e70fB3",
         "poolAddress": "0x7fC77b5c7614E1533320Ea6DDc2Eb61fa00A9714"
@@ -28,6 +30,7 @@
         "decimals": 18,
         "scope": "v2",
         "type": "btc",
+        "withdrawOnly": false,
         "address": "0x7047F90229a057C13BF847C0744D646CFb6c9E1A",
         "tokenAddress": "0x49849C98ae39Fff122806C06791Fa73784FB3675",
         "poolAddress": "0x93054188d876f558f4a66B2EF1d97d16eDf0895B"
@@ -39,6 +42,7 @@
         "decimals": 18,
         "scope": "v2",
         "type": "aave",
+        "withdrawOnly": false,
         "address": "0xb4D1Be44BfF40ad6e506edf43156577a3f8672eC",
         "tokenAddress": "0x02d341CcB60fAaf662bC0554d13778015d1b285C",
         "poolAddress": "0xeb16ae0052ed37f479f7fe63849198df1765a733"
@@ -50,6 +54,7 @@
         "decimals": 18,
         "scope": "v2",
         "type": "btc",
+        "withdrawOnly": false,
         "address": "0xe9Dc63083c464d6EDcCFf23444fF3CFc6886f6FB",
         "tokenAddress": "0x2fE94ea3d5d4a175184081439753DE15AeF9d614",
 		"poolAddress": "0xd81da8d904b52208541bade1bd6595d8a251f8dd"
@@ -61,6 +66,7 @@
         "decimals": 18,
         "scope": "v2",
         "type": "btc",
+        "withdrawOnly": false,
         "address": "0x3c5DF3077BcF800640B5DAE8c91106575a4826E6",
         "tokenAddress": "0xDE5331AC4B3630f94853Ff322B66407e0D6331E8",
 		"poolAddress": "0x7f55dde206dbad629c080068923b36fe9d6bdbef"
@@ -72,6 +78,7 @@
         "decimals": 18,
         "scope": "v2",
         "type": "usd",
+        "withdrawOnly": false,
         "address": "0x5fA5B62c8AF877CB37031e0a3B2f34A78e3C56A6",
         "tokenAddress": "0xEd279fDD11cA84bEef15AF5D39BB4d4bEE23F0cA",
 		"poolAddress": "0xEd279fDD11cA84bEef15AF5D39BB4d4bEE23F0cA"
@@ -83,6 +90,7 @@
         "decimals": 18,
         "scope": "v2",
         "type": "btc",
+        "withdrawOnly": false,
         "address": "0x8fA3A9ecd9EFb07A8CE90A6eb014CF3c0E3B32Ef",
         "tokenAddress": "0x410e3E86ef427e30B9235497143881f717d93c2A",
 		"poolAddress": "0x071c661b4deefb59e2a3ddb20db036821eee8f4b"
@@ -94,6 +102,7 @@
         "decimals": 18,
         "scope": "v2",
         "type": "btc",
+        "withdrawOnly": false,
         "address": "0x23D3D0f1c697247d5e0a9efB37d8b0ED0C464f7f",
         "tokenAddress": "0x64eda51d3Ad40D56b9dFc5554E06F94e1Dd786Fd",
 		"poolAddress": "0xC25099792E9349C7DD09759744ea681C7de2cb66"
@@ -105,6 +114,7 @@
         "decimals": 18,
         "scope": "v2",
         "type": "usd",
+        "withdrawOnly": false,
         "address": "0xB4AdA607B9d6b2c9Ee07A275e9616B84AC560139",
         "tokenAddress": "0xd632f22692FaC7611d2AA1C0D552930D43CAEd3B",
         "poolAddress": "0xd632f22692FaC7611d2AA1C0D552930D43CAEd3B"
@@ -116,6 +126,7 @@
         "decimals": 18,
         "scope": "v2",
         "type": "usd",
+        "withdrawOnly": false,
         "address": "0x8ee57c05741aA9DB947A744E713C15d4d19D8822",
         "tokenAddress": "0x3B3Ac5386837Dc563660FB6a0937DFAa5924333B",
         "poolAddress": "0x79a8C46DeA5aDa233ABaFFD40F3A0A2B1e5A4F27"
@@ -127,6 +138,7 @@
         "decimals": 18,
         "scope": "v2",
         "type": "usd",
+        "withdrawOnly": false,
         "address": "0x2a38B9B0201Ca39B17B460eD2f11e4929559071E",
         "tokenAddress": "0xD2967f45c4f384DEEa880F807Be904762a3DeA07",
         "poolAddress": "0x4f062658EaAF2C1ccf8C8e36D6824CDf41167956"
@@ -138,6 +150,7 @@
         "decimals": 18,
         "scope": "v2",
         "type": "usd",
+        "withdrawOnly": false,
         "address": "0x4B5BfD52124784745c1071dcB244C6688d2533d3",
         "tokenAddress": "0xdF5e0e81Dff6FAF3A7e52BA697820c5e32D806A8",
         "poolAddress": "0x45F783CCE6B7FF23B2ab2D70e416cdb7D6055f51"
@@ -149,6 +162,7 @@
         "decimals": 18,
         "scope": "v2",
         "type": "usd",
+        "withdrawOnly": false,
         "address": "0x84E13785B5a27879921D6F685f041421C7F482dA",
         "tokenAddress": "0x6c3F90f043a72FA612cbac8115EE7e52BDe6E490",
         "poolAddress": "0xbEbc44782C7dB0a1A60Cb6fe97d0b483032FF1C7"
@@ -159,6 +173,7 @@
         "name": "yvCurve-TUSD 0.3.5",
         "decimals": 18,
         "type": "usd",
+        "withdrawOnly": false,
         "scope": "v2",
         "address": "0xf8768814b88281DE4F532a3beEfA5b85B69b9324",
         "tokenAddress": "0xEcd5e75AFb02eFa118AF914515D6521aaBd189F1",
@@ -171,6 +186,7 @@
         "decimals": 18,
         "scope": "v2",
         "type": "usd",
+        "withdrawOnly": false,
         "address": "0x6Ede7F19df5df6EF23bD5B9CeDb651580Bdf56Ca",
         "tokenAddress": "0x4807862AA8b2bF68830e4C8dc86D0e9A998e085a",
 		"poolAddress": "0x4807862AA8b2bF68830e4C8dc86D0e9A998e085a"
@@ -182,6 +198,7 @@
         "decimals": 18,
         "scope": "v2",
         "type": "usd",
+        "withdrawOnly": false,
         "address": "0x30FCf7c6cDfC46eC237783D94Fc78553E79d4E9C",
         "tokenAddress": "0x3a664Ab939FD8482048609f652f9a0B0677337B9",
 		"poolAddress": "0x8038C01A0390a8c547446a0b2c18fc9aEFEcc10c"
@@ -193,6 +210,7 @@
         "decimals": 18,
         "scope": "v2",
         "type": "usd",
+        "withdrawOnly": false,
         "address": "0x1C6a9783F812b3Af3aBbf7de64c3cD7CC7D1af44",
         "tokenAddress": "0x94e131324b6054c0D789b190b2dAC504e4361b53",
 		"poolAddress": "0x890f4e345b1daed0367a877a1612f86a1f86985f"
@@ -204,6 +222,7 @@
         "decimals": 18,
         "scope": "v2",
         "type": "usd",
+        "withdrawOnly": false,
         "address": "0x8cc94ccd0f3841a468184aCA3Cc478D2148E1757",
         "tokenAddress": "0x1AEf73d49Dedc4b1778d0706583995958Dc862e6",
 		"poolAddress": "0x8474DdbE98F5aA3179B3B3F5942D724aFcdec9f6"
@@ -215,6 +234,7 @@
         "decimals": 18,
         "scope": "v2",
         "type": "usd",
+        "withdrawOnly": false,
         "address": "0x5a770DbD3Ee6bAF2802D29a901Ef11501C44797A",
         "tokenAddress": "0xC25a3A3b969415c80451098fa907EC722572917F",
         "poolAddress": "0xA5407eAE9Ba41422680e2e00537571bcC53efBfD"
@@ -226,6 +246,7 @@
         "decimals": 18,
         "scope": "v2",
         "type": "usd",
+        "withdrawOnly": false,
         "address": "0x3B96d491f067912D18563d56858Ba7d6EC67a6fa",
         "tokenAddress": "0x4f3E8F405CF5aFC05D68142F3783bDfE13811522",
 		"poolAddress": "0x0f9cb53Ebe405d49A0bbdBD291A65Ff571bC83e1"
@@ -237,6 +258,7 @@
         "decimals": 18,
         "scope": "v2",
         "type": "usd",
+        "withdrawOnly": false,
         "address": "0xC4dAf3b5e2A9e93861c3FBDd25f1e943B8D87417",
         "tokenAddress": "0x7Eb40E450b9655f4B3cC4259BCC731c63ff55ae6",
 		"poolAddress": "0x42d7025938bEc20B69cBae5A77421082407f053A"
@@ -248,6 +270,7 @@
         "decimals": 18,
         "scope": "v2",
         "type": "usd",
+        "withdrawOnly": false,
         "address": "0xA74d4B67b3368E83797a35382AFB776bAAE4F5C8",
         "tokenAddress": "0x43b4FdFD4Ff969587185cDB6f0BD875c5Fc83f8c",
 		"poolAddress": "0x43b4FdFD4Ff969587185cDB6f0BD875c5Fc83f8c"
@@ -259,6 +282,7 @@
         "decimals": 18,
         "scope": "v2",
         "type": "aave",
+        "withdrawOnly": false,
         "address": "0x39CAF13a104FF567f71fd2A4c68C026FDB6E740B",
         "tokenAddress": "0xFd2a8fA60Abd58Efe3EeE34dd494cD491dC14900",
         "poolAddress": "0xdebf20617708857ebe4f679508e7b7863a8a8eee"
@@ -270,9 +294,22 @@
         "decimals": 18,
         "scope": "v2",
         "type": "usd",
+        "withdrawOnly": false,
         "address": "0x054AF22E1519b020516D72D749221c24756385C9",
         "tokenAddress": "0x5B5CFE992AdAC0C9D48E05854B2d91C73a003858",
 		"poolAddress": "0x3eF6A01A0f81D6046290f3e2A8c5b843e738E604"
+    },
+    {
+        "icon": "https://rawcdn.githack.com/yearn/yearn-assets/3fa15c2e51ff3ed4dac8bd124a7bfa8888b3b78c/icons/tokens/0x3D980E50508CFd41a13837A60149927a11c03731/logo-128.png",
+        "symbol": "yvCurve-triCrypto",
+        "name": "yvCurve-triCrypto 0.4.2",
+        "decimals": 18,
+        "scope": "v2",
+        "type": "tri",
+        "withdrawOnly": true,
+        "address": "0x3D980E50508CFd41a13837A60149927a11c03731",
+        "tokenAddress": "0xcA3d75aC011BF5aD07a98d02f18225F9bD9A6BDF",
+        "poolAddress": "0x80466c64868e1ab14a1ddf27a676c3fcbe638fe5"
     },
     {
         "icon": "https://rawcdn.githack.com/yearn/yearn-assets/3fa15c2e51ff3ed4dac8bd124a7bfa8888b3b78c/icons/tokens/0x3D27705c64213A5DcD9D26880c1BcFa72d5b6B0E/logo-128.png",
@@ -281,6 +318,7 @@
         "decimals": 18,
         "scope": "v2",
         "type": "usd",
+        "withdrawOnly": false,
         "address": "0x3D27705c64213A5DcD9D26880c1BcFa72d5b6B0E",
         "tokenAddress": "0x97E2768e8E73511cA874545DC5Ff8067eB19B787",
         "poolAddress": "0x3E01dD8a5E1fb3481F0F589056b428Fc308AF0Fb"
@@ -292,6 +330,7 @@
         "decimals": 18,
         "scope": "v2",
         "type": "usd",
+        "withdrawOnly": false,
         "address": "0xC116dF49c02c5fD147DE25Baa105322ebF26Bd97",
         "tokenAddress": "0xC2Ee6b0334C261ED60C72f6054450b61B8f18E35",
         "poolAddress": "0xC18cC39da8b11dA8c3541C598eE022258F9744da"
@@ -303,6 +342,7 @@
         "decimals": 18,
         "scope": "v2",
         "type": "tri",
+        "withdrawOnly": false,
         "address": "0xE537B5cc158EB71037D4125BDD7538421981E6AA",
         "tokenAddress": "0xc4AD29ba4B3c580e6D59105FFf484999997675Ff",
         "poolAddress": "0xd51a44d3fae010294c616388b506acda1bfaae46"
@@ -314,6 +354,7 @@
         "decimals": 18,
         "scope": "v2",
         "type": "link",
+        "withdrawOnly": false,
         "address": "0xf2db9a7c0ACd427A680D640F02d90f6186E71725",
         "tokenAddress": "0xcee60cFa923170e4f8204AE08B4fA6A3F5656F3a",
         "poolAddress": "0xf178c0b5bb7e7abf4e12a4838c7b7c5ba2c623c0"
@@ -325,6 +366,7 @@
         "decimals": 18,
         "scope": "v2",
         "type": "link",
+        "withdrawOnly": false,
         "address": "0x671a912C10bba0CFA74Cfc2d6Fba9BA1ed9530B2",
         "tokenAddress": "0x514910771AF9Ca656af840dff83E8264EcF986CA",
         "poolAddress": "0xf178c0b5bb7e7abf4e12a4838c7b7c5ba2c623c0"
@@ -337,6 +379,7 @@
 		"decimals": 18,
         "scope": "v2",
 		"type": "usd",
+        "withdrawOnly": false,
 		"address": "0x2DfB14E32e2F8156ec15a2c21c3A6c053af52Be8",
 		"tokenAddress": "0x5a6A4D54456819380173272A5E8E9B9904BdF41B",
         "poolAddress": "0x5a6A4D54456819380173272A5E8E9B9904BdF41B"

--- a/utils/BOWSWAP_CRV_V2_VAULTS.json
+++ b/utils/BOWSWAP_CRV_V2_VAULTS.json
@@ -275,17 +275,6 @@
 		"poolAddress": "0x3eF6A01A0f81D6046290f3e2A8c5b843e738E604"
     },
     {
-        "icon": "https://rawcdn.githack.com/yearn/yearn-assets/3fa15c2e51ff3ed4dac8bd124a7bfa8888b3b78c/icons/tokens/0x3D980E50508CFd41a13837A60149927a11c03731/logo-128.png",
-        "symbol": "yvCurve-triCrypto",
-        "name": "yvCurve-triCrypto 0.4.2",
-        "decimals": 18,
-        "scope": "v2",
-        "type": "tri",
-        "address": "0x3D980E50508CFd41a13837A60149927a11c03731",
-        "tokenAddress": "0xcA3d75aC011BF5aD07a98d02f18225F9bD9A6BDF",
-        "poolAddress": "0x80466c64868e1ab14a1ddf27a676c3fcbe638fe5"
-    },
-    {
         "icon": "https://rawcdn.githack.com/yearn/yearn-assets/3fa15c2e51ff3ed4dac8bd124a7bfa8888b3b78c/icons/tokens/0x3D27705c64213A5DcD9D26880c1BcFa72d5b6B0E/logo-128.png",
         "symbol": "yvCurve-USDK",
         "name": "yvCurve-USDK 0.3.5",


### PR DESCRIPTION
## Description
The vault yvCurve-triCrypto and been deprecated (deposit limit = 0). Therefore, remove it from the migrations `TO` list.

## Type of change
- [X] New feature (non-breaking change which adds functionality)

## Change details
A new property has been added to the JSON file : `withdrawOnly`. If it's withdraw only, the vault will not be displayed in the `toVault` modal.
Users will be able to move funds from theses vaults but not in theses vaults.

## Resources
*N/A*